### PR TITLE
Py3 compatibility fix

### DIFF
--- a/cinder/tests/unit/windows/test_windows_utils.py
+++ b/cinder/tests/unit/windows/test_windows_utils.py
@@ -30,6 +30,15 @@ class WindowsUtilsTestCase(test.TestCase):
         self.wutils._conn_cimv2 = mock.MagicMock()
         self.wutils._vhdutils = mock.MagicMock()
 
+    @mock.patch.object(windows_utils.WindowsUtils, 'get_windows_version')
+    def test_check_min_windows_version(self, mock_get_win_version):
+        required_win_version = [6, 4]
+        actual_win_version = '6.3.0'
+        mock_get_win_version.return_value = actual_win_version
+
+        self.assertFalse(self.wutils.check_min_windows_version(
+            *required_win_version))
+
     def _test_copy_vhd_disk(self, source_exists=True, copy_failed=False):
         fake_data_file_object = mock.MagicMock()
         fake_data_file_object.Copy.return_value = [int(copy_failed)]

--- a/cinder/volume/drivers/windows/windows_utils.py
+++ b/cinder/volume/drivers/windows/windows_utils.py
@@ -438,7 +438,7 @@ class WindowsUtils(object):
 
     def check_min_windows_version(self, major, minor, build=0):
         version_str = self.get_windows_version()
-        return map(int, version_str.split('.')) >= [major, minor, build]
+        return list(map(int, version_str.split('.'))) >= [major, minor, build]
 
     def get_windows_version(self):
         return self._conn_cimv2.Win32_OperatingSystem()[0].Version


### PR DESCRIPTION
Minor changes for Python 3 compatibility in the
Windows iSCSI and SMB3 drivers.

Change-Id: I64ee3c929e4142357c076e5de91ff68c0cb3c399
Partial-Implements: blueprint cinder-python3
