### PR TITLE
SMBFS: Store the format as extension for all formats

### DIFF
--- a/cinder/tests/unit/test_smbfs.py
+++ b/cinder/tests/unit/test_smbfs.py
@@ -89,6 +89,8 @@ class SmbFsTestCase(test.TestCase):
         self._smbfs_driver._alloc_info_file_path = (
             self._FAKE_ALLOCATION_DATA_PATH)
 
+        self.addCleanup(mock.patch.stopall)
+
     def _get_fake_allocation_data(self):
         return {self._FAKE_SHARE_HASH: {
                 'total_allocated': self._FAKE_TOTAL_ALLOCATED}}
@@ -237,51 +239,49 @@ class SmbFsTestCase(test.TestCase):
         fake_config.smbfs_used_ratio = 1.1
         self._test_setup(config=fake_config)
 
-    def _test_create_volume(self, volume_exists=False, volume_format=None):
-        fake_method = mock.MagicMock()
+    @mock.patch('os.path.exists')
+    def _test_create_volume(self, mock_exists, volume_exists=False,
+                            volume_format=None, use_sparsed_file=False):
+        mock.patch.multiple(smbfs.SmbfsDriver,
+                            _create_windows_image=mock.DEFAULT,
+                            _create_regular_file=mock.DEFAULT,
+                            _create_qcow2_file=mock.DEFAULT,
+                            _create_sparsed_file=mock.DEFAULT,
+                            get_volume_format=mock.DEFAULT,
+                            local_path=mock.DEFAULT,
+                            _set_rw_permissions_for_all=mock.DEFAULT).start()
         self._smbfs_driver.configuration = copy.copy(self._FAKE_SMBFS_CONFIG)
-        self._smbfs_driver._set_rw_permissions_for_all = mock.MagicMock()
-        fake_set_permissions = self._smbfs_driver._set_rw_permissions_for_all
-        self._smbfs_driver.get_volume_format = mock.MagicMock()
+        self._smbfs_driver.configuration.smbfs_sparsed_volumes = (
+            use_sparsed_file)
 
-        windows_image_format = False
-        fake_vol_path = self._FAKE_VOLUME_PATH
         self._smbfs_driver.get_volume_format.return_value = volume_format
+        self._smbfs_driver.local_path.return_value = mock.sentinel.vol_path
+        mock_exists.return_value = volume_exists
 
-        if volume_format:
-            if volume_format in ('vhd', 'vhdx'):
-                windows_image_format = volume_format
-                if volume_format == 'vhd':
-                    windows_image_format = 'vpc'
-                method = '_create_windows_image'
-                fake_vol_path += '.' + volume_format
-            else:
-                method = '_create_%s_file' % volume_format
-                if volume_format == 'sparsed':
-                    self._smbfs_driver.configuration.smbfs_sparsed_volumes = (
-                        True)
+        if volume_exists:
+            self.assertRaises(exception.InvalidVolume,
+                              self._smbfs_driver._do_create_volume,
+                              self._FAKE_VOLUME)
+            return
+
+        self._smbfs_driver._do_create_volume(self._FAKE_VOLUME)
+        expected_create_args = [mock.sentinel.vol_path,
+                                self._FAKE_VOLUME['size']]
+        if volume_format in [self._smbfs_driver._DISK_FORMAT_VHDX,
+                             self._smbfs_driver._DISK_FORMAT_VHD]:
+            expected_create_args.append(volume_format)
+            exp_create_method = self._smbfs_driver._create_windows_image
         else:
-            method = '_create_regular_file'
-
-        setattr(self._smbfs_driver, method, fake_method)
-
-        with mock.patch('os.path.exists', new=lambda x: volume_exists):
-            if volume_exists:
-                self.assertRaises(exception.InvalidVolume,
-                                  self._smbfs_driver._do_create_volume,
-                                  self._FAKE_VOLUME)
-                return
-
-            self._smbfs_driver._do_create_volume(self._FAKE_VOLUME)
-            if windows_image_format:
-                fake_method.assert_called_once_with(
-                    fake_vol_path,
-                    self._FAKE_VOLUME['size'],
-                    windows_image_format)
+            if volume_format == self._smbfs_driver._DISK_FORMAT_QCOW2:
+                exp_create_method = self._smbfs_driver._create_qcow2_file
+            elif use_sparsed_file:
+                exp_create_method = self._smbfs_driver._create_sparsed_file
             else:
-                fake_method.assert_called_once_with(
-                    fake_vol_path, self._FAKE_VOLUME['size'])
-            fake_set_permissions.assert_called_once_with(fake_vol_path)
+                exp_create_method = self._smbfs_driver._create_regular_file
+
+        exp_create_method.assert_called_once_with(*expected_create_args)
+        mock_set_permissions = self._smbfs_driver._set_rw_permissions_for_all
+        mock_set_permissions.assert_called_once_with(mock.sentinel.vol_path)
 
     def test_create_existing_volume(self):
         self._test_create_volume(volume_exists=True)
@@ -293,7 +293,8 @@ class SmbFsTestCase(test.TestCase):
         self._test_create_volume(volume_format='qcow2')
 
     def test_create_sparsed(self):
-        self._test_create_volume(volume_format='sparsed')
+        self._test_create_volume(volume_format='raw',
+                                 use_sparsed_file=True)
 
     def test_create_regular(self):
         self._test_create_volume()
@@ -387,14 +388,12 @@ class SmbFsTestCase(test.TestCase):
     @mock.patch.object(smbfs.SmbfsDriver, '_lookup_local_volume_path')
     @mock.patch.object(smbfs.SmbfsDriver, 'get_volume_format')
     def _test_get_volume_path(self, mock_get_volume_format, mock_lookup_volume,
-                              mock_get_path_template, volume_exists=True,
-                              volume_format='raw'):
+                              mock_get_path_template, volume_exists=True):
         drv = self._smbfs_driver
         mock_get_path_template.return_value = self._FAKE_VOLUME_PATH
+        volume_format = 'raw'
 
-        expected_vol_path = self._FAKE_VOLUME_PATH
-        if volume_format in (drv._DISK_FORMAT_VHD, drv._DISK_FORMAT_VHDX):
-            expected_vol_path += '.' + volume_format
+        expected_vol_path = self._FAKE_VOLUME_PATH + '.' + volume_format
 
         mock_lookup_volume.return_value = (
             expected_vol_path if volume_exists else None)
@@ -411,11 +410,8 @@ class SmbFsTestCase(test.TestCase):
     def test_get_existing_volume_path(self):
         self._test_get_volume_path()
 
-    def test_get_new_raw_volume_path(self):
+    def test_get_new_volume_path(self):
         self._test_get_volume_path(volume_exists=False)
-
-    def test_get_new_vhd_volume_path(self):
-        self._test_get_volume_path(volume_exists=False, volume_format='vhd')
 
     @mock.patch.object(smbfs.SmbfsDriver, '_local_volume_dir')
     def test_get_local_volume_path_template(self, mock_get_local_dir):
@@ -432,8 +428,11 @@ class SmbFsTestCase(test.TestCase):
         ret_val = self._smbfs_driver._lookup_local_volume_path(
             self._FAKE_VOLUME_PATH)
 
+        extensions = [''] + [
+            ".%s" % ext
+            for ext in self._smbfs_driver._SUPPORTED_IMAGE_FORMATS]
         possible_paths = [self._FAKE_VOLUME_PATH + ext
-                          for ext in ('', '.vhd', '.vhdx')]
+                          for ext in extensions]
         mock_exists.assert_has_calls(
             [mock.call(path) for path in possible_paths])
         self.assertEqual(expected_path, ret_val)
@@ -490,11 +489,11 @@ class SmbFsTestCase(test.TestCase):
         self._smbfs_driver._get_mount_point_base = mock.Mock(
             return_value=self._FAKE_MNT_BASE)
         self._smbfs_driver.shares = {self._FAKE_SHARE: self._FAKE_SHARE_OPTS}
-        self._smbfs_driver._qemu_img_info = mock.Mock(
-            return_value=mock.Mock(file_format='raw'))
+        self._smbfs_driver.get_volume_format = mock.Mock(
+            return_value=mock.sentinel.format)
 
         fake_data = {'export': self._FAKE_SHARE,
-                     'format': 'raw',
+                     'format': mock.sentinel.format,
                      'name': self._FAKE_VOLUME_NAME,
                      'options': self._FAKE_SHARE_OPTS}
         expected = {

--- a/cinder/volume/drivers/remotefs.py
+++ b/cinder/volume/drivers/remotefs.py
@@ -692,8 +692,8 @@ class RemoteFSSnapDriver(RemoteFSDriver, driver.SnapshotVD):
             info.image = os.path.basename(info.image)
         if info.backing_file:
             backing_file_template = \
-                "(%(basedir)s/[0-9a-f]+/)?%" \
-                "(volname)s(.(tmp-snap-)?[0-9a-f-]+)?$" % {
+                r"(%(basedir)s/[0-9a-f]+/)?%" \
+                r"(volname)s(.(tmp-snap-)?[0-9a-f-]+)?(\.\w+)?$" % {
                     'basedir': basedir,
                     'volname': volume_name
                 }

--- a/cinder/volume/drivers/smbfs.py
+++ b/cinder/volume/drivers/smbfs.py
@@ -114,6 +114,9 @@ class SmbfsDriver(remotefs_drv.RemoteFSSnapDriver):
     _DISK_FORMAT_RAW = 'raw'
     _DISK_FORMAT_QCOW2 = 'qcow2'
 
+    _SUPPORTED_IMAGE_FORMATS = [_DISK_FORMAT_RAW, _DISK_FORMAT_QCOW2,
+                                _DISK_FORMAT_VHD, _DISK_FORMAT_VHDX]
+
     def __init__(self, execute=putils.execute, *args, **kwargs):
         self._remotefsclient = None
         super(SmbfsDriver, self).__init__(*args, **kwargs)
@@ -145,19 +148,7 @@ class SmbfsDriver(remotefs_drv.RemoteFSSnapDriver):
         """
         # Find active image
         active_file = self.get_active_image_from_info(volume)
-        active_file_path = os.path.join(self._local_volume_dir(volume),
-                                        active_file)
-
-        try:
-            info = self._qemu_img_info(active_file_path, volume['name'])
-            fmt = info.file_format
-        except Exception as exc:
-            LOG.warning(_LW("Could not retrieve the image format while "
-                            "providing volume %(volume_id)s connection info. "
-                            "Exception: %(exc)s"),
-                        dict(volume_id=volume['id'],
-                             exc=exc))
-            fmt = None
+        fmt = self.get_volume_format(volume)
 
         data = {'export': volume['provider_location'],
                 'format': fmt,
@@ -262,10 +253,7 @@ class SmbfsDriver(remotefs_drv.RemoteFSSnapDriver):
         # The image does not exist, so retrieve the volume format
         # in order to build the path.
         fmt = self.get_volume_format(volume)
-        if fmt in (self._DISK_FORMAT_VHD, self._DISK_FORMAT_VHDX):
-            volume_path = volume_path_template + '.' + fmt
-        else:
-            volume_path = volume_path_template
+        volume_path = volume_path_template + '.' + fmt
         return volume_path
 
     def _get_local_volume_path_template(self, volume):
@@ -274,7 +262,7 @@ class SmbfsDriver(remotefs_drv.RemoteFSSnapDriver):
         return local_path_template
 
     def _lookup_local_volume_path(self, volume_path_template):
-        for ext in ['', self._DISK_FORMAT_VHD, self._DISK_FORMAT_VHDX]:
+        for ext in [''] + self._SUPPORTED_IMAGE_FORMATS:
             volume_path = (volume_path_template + '.' + ext
                            if ext else volume_path_template)
             if os.path.exists(volume_path):
@@ -294,8 +282,12 @@ class SmbfsDriver(remotefs_drv.RemoteFSSnapDriver):
         volume_path = self._lookup_local_volume_path(volume_path_template)
 
         if volume_path:
-            info = self._qemu_img_info(volume_path, volume['name'])
-            volume_format = info.file_format
+            ext = os.path.splitext(volume_path)[1].strip('.').lower()
+            if ext in self._SUPPORTED_IMAGE_FORMATS:
+                volume_format = ext
+            else:
+                info = self._qemu_img_info(volume_path, volume['name'])
+                volume_format = info.file_format
         else:
             volume_format = (
                 self._get_volume_format_spec(volume) or


### PR DESCRIPTION
Storing the volume format as an extension for all the supported
formats lets us retrieve it easier, even if the image is in use.

This change won't affect existing volumes.
