### PR TITLE
Move windows drivers to versioned objects

### DIFF
--- a/cinder/tests/unit/windows/test_windows.py
+++ b/cinder/tests/unit/windows/test_windows.py
@@ -24,8 +24,11 @@ import os
 from oslo_utils import fileutils
 from oslo_utils import units
 
+from cinder import context
 from cinder.image import image_utils
 from cinder import test
+from cinder.tests.unit import fake_snapshot
+from cinder.tests.unit import fake_volume
 from cinder.tests.unit.windows import db_fakes
 from cinder.volume import configuration as conf
 from cinder.volume.drivers.windows import windows
@@ -64,10 +67,12 @@ class TestWindowsDriver(test.TestCase):
         fake_chap_username = 'fake_chap_username'
         fake_chap_password = 'fake_chap_password'
         fake_host_info = {'fake_prop': 'fake_value'}
-        fake_volume = db_fakes.get_fake_volume_info()
-        fake_volume['provider_auth'] = "%s %s %s" % (fake_auth_meth,
-                                                     fake_chap_username,
-                                                     fake_chap_password)
+        fake_provider_auth = "%s %s %s" % (fake_auth_meth,
+                                           fake_chap_username,
+                                           fake_chap_password)
+
+        volume = fake_volume.fake_volume_obj(mock.sentinel.context,
+                                             provider_auth=fake_provider_auth)
 
         mock_get_target_name.return_value = mock.sentinel.target_name
         tgt_utils.get_portal_locations.return_value = [
@@ -81,13 +86,13 @@ class TestWindowsDriver(test.TestCase):
                                   target_discovered=False,
                                   target_portal=mock.sentinel.portal_location,
                                   target_lun=0,
-                                  volume_id=fake_volume['id'])
+                                  volume_id=volume.id)
 
-        host_info = self._driver._get_host_information(fake_volume)
+        host_info = self._driver._get_host_information(volume)
 
         self.assertEqual(expected_host_info, host_info)
 
-        mock_get_target_name.assert_called_once_with(fake_volume)
+        mock_get_target_name.assert_called_once_with(volume)
         tgt_utils.get_portal_locations.assert_called_once_with()
         tgt_utils.get_target_information.assert_called_once_with(
             mock.sentinel.target_name)
@@ -96,7 +101,7 @@ class TestWindowsDriver(test.TestCase):
     def test_initialize_connection(self, mock_get_host_info):
         tgt_utils = self._driver._tgt_utils
 
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
         fake_initiator = db_fakes.get_fake_connector_info()
         fake_host_info = {'fake_host_prop': 'fake_value'}
 
@@ -104,38 +109,38 @@ class TestWindowsDriver(test.TestCase):
 
         expected_conn_info = {'driver_volume_type': 'iscsi',
                               'data': fake_host_info}
-        conn_info = self._driver.initialize_connection(fake_volume,
+        conn_info = self._driver.initialize_connection(volume,
                                                        fake_initiator)
 
         self.assertEqual(expected_conn_info, conn_info)
         mock_associate = tgt_utils.associate_initiator_with_iscsi_target
         mock_associate.assert_called_once_with(
             fake_initiator['initiator'],
-            fake_volume['provider_location'])
+            volume.provider_location)
 
     def test_terminate_connection(self):
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
         fake_initiator = db_fakes.get_fake_connector_info()
 
-        self._driver.terminate_connection(fake_volume, fake_initiator)
+        self._driver.terminate_connection(volume, fake_initiator)
 
         self._driver._tgt_utils.deassociate_initiator.assert_called_once_with(
-            fake_initiator['initiator'], fake_volume['provider_location'])
+            fake_initiator['initiator'], volume.provider_location)
 
     @mock.patch.object(windows.WindowsDriver, 'local_path')
     def test_create_volume(self, mock_local_path):
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
 
-        self._driver.create_volume(fake_volume)
+        self._driver.create_volume(volume)
 
-        mock_local_path.assert_called_once_with(fake_volume)
+        mock_local_path.assert_called_once_with(volume)
         self._driver._tgt_utils.create_wt_disk.assert_called_once_with(
             mock_local_path.return_value,
-            fake_volume['name'],
-            size_mb=fake_volume['size'] * 1024)
+            volume.name,
+            size_mb=volume.size * 1024)
 
     def test_local_path(self):
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
 
         fake_lun_path = 'fake_lun_path'
         self.flags(windows_iscsi_lun_path=fake_lun_path)
@@ -144,9 +149,9 @@ class TestWindowsDriver(test.TestCase):
         mock_get_fmt = self._driver._tgt_utils.get_supported_disk_format
         mock_get_fmt.return_value = disk_format
 
-        disk_path = self._driver.local_path(fake_volume)
+        disk_path = self._driver.local_path(volume)
 
-        expected_fname = "%s.%s" % (fake_volume['name'], disk_format)
+        expected_fname = "%s.%s" % (volume.name, disk_format)
         expected_disk_path = os.path.join(fake_lun_path,
                                           expected_fname)
         self.assertEqual(expected_disk_path, disk_path)
@@ -155,53 +160,55 @@ class TestWindowsDriver(test.TestCase):
     @mock.patch.object(windows.WindowsDriver, 'local_path')
     @mock.patch.object(fileutils, 'delete_if_exists')
     def test_delete_volume(self, mock_delete_if_exists, mock_local_path):
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
 
-        self._driver.delete_volume(fake_volume)
+        self._driver.delete_volume(volume)
 
-        mock_local_path.assert_called_once_with(fake_volume)
+        mock_local_path.assert_called_once_with(volume)
         self._driver._tgt_utils.remove_wt_disk.assert_called_once_with(
-            fake_volume['name'])
+            volume.name)
         mock_delete_if_exists.assert_called_once_with(
             mock_local_path.return_value)
 
     def test_create_snapshot(self):
-        fake_snapshot = db_fakes.get_fake_snapshot_info()
+        volume = fake_volume.fake_volume_obj(context.get_admin_context())
+        snapshot = fake_snapshot.fake_snapshot_obj(context.get_admin_context(),
+                                                   volume_id=volume.id)
+        snapshot.volume = volume
 
-        self._driver.create_snapshot(fake_snapshot)
+        self._driver.create_snapshot(snapshot)
 
         self._driver._tgt_utils.create_snapshot.assert_called_once_with(
-            fake_snapshot['volume_name'], fake_snapshot['name'])
+            snapshot.volume_name, snapshot.name)
 
     @mock.patch.object(windows.WindowsDriver, 'local_path')
     def test_create_volume_from_snapshot(self, mock_local_path):
-        fake_volume = db_fakes.get_fake_volume_info()
-        fake_snapshot = db_fakes.get_fake_snapshot_info()
+        volume = fake_volume.fake_volume_obj(context.get_admin_context())
+        snapshot = fake_snapshot.fake_snapshot_obj(context.get_admin_context())
+        snapshot.volume = volume
 
-        self._driver.create_volume_from_snapshot(fake_volume, fake_snapshot)
+        self._driver.create_volume_from_snapshot(volume, snapshot)
 
         self._driver._tgt_utils.export_snapshot.assert_called_once_with(
-            fake_snapshot['name'],
-            mock_local_path.return_value)
+            snapshot.name, mock_local_path.return_value)
         self._driver._tgt_utils.import_wt_disk.assert_called_once_with(
-            mock_local_path.return_value,
-            fake_volume['name'])
+            mock_local_path.return_value, volume.name)
 
     def test_delete_snapshot(self):
-        fake_snapshot = db_fakes.get_fake_snapshot_info()
+        snapshot = fake_snapshot.fake_snapshot_obj(context.get_admin_context())
 
-        self._driver.delete_snapshot(fake_snapshot)
+        self._driver.delete_snapshot(snapshot)
 
         self._driver._tgt_utils.delete_snapshot.assert_called_once_with(
-            fake_snapshot['name'])
+            snapshot.name)
 
     def test_get_target_name(self):
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
         expected_target_name = "%s%s" % (
             self._driver.configuration.iscsi_target_prefix,
-            fake_volume['name'])
+            volume.name)
 
-        target_name = self._driver._get_target_name(fake_volume)
+        target_name = self._driver._get_target_name(volume)
         self.assertEqual(expected_target_name, target_name)
 
     @mock.patch.object(windows.WindowsDriver, '_get_target_name')
@@ -211,7 +218,7 @@ class TestWindowsDriver(test.TestCase):
                            mock_generate_username,
                            mock_get_target_name):
         tgt_utils = self._driver._tgt_utils
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
         self._driver.configuration.chap_username = None
         self._driver.configuration.chap_password = None
         self._driver.configuration.use_chap_auth = True
@@ -224,10 +231,10 @@ class TestWindowsDriver(test.TestCase):
         tgt_utils.iscsi_target_exists.return_value = False
 
         vol_updates = self._driver.create_export(mock.sentinel.context,
-                                                 fake_volume,
+                                                 volume,
                                                  mock.sentinel.connector)
 
-        mock_get_target_name.assert_called_once_with(fake_volume)
+        mock_get_target_name.assert_called_once_with(volume)
         tgt_utils.iscsi_target_exists.assert_called_once_with(
             mock.sentinel.target_name)
         tgt_utils.set_chap_credentials.assert_called_once_with(
@@ -235,7 +242,7 @@ class TestWindowsDriver(test.TestCase):
             fake_chap_username,
             fake_chap_password)
         tgt_utils.add_disk_to_target.assert_called_once_with(
-            fake_volume['name'], mock.sentinel.target_name)
+            volume.name, mock.sentinel.target_name)
 
         expected_provider_auth = ' '.join(('CHAP',
                                            fake_chap_username,
@@ -247,11 +254,11 @@ class TestWindowsDriver(test.TestCase):
 
     @mock.patch.object(windows.WindowsDriver, '_get_target_name')
     def test_remove_export(self, mock_get_target_name):
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
 
-        self._driver.remove_export(mock.sentinel.context, fake_volume)
+        self._driver.remove_export(mock.sentinel.context, volume)
 
-        mock_get_target_name.assert_called_once_with(fake_volume)
+        mock_get_target_name.assert_called_once_with(volume)
         self._driver._tgt_utils.delete_iscsi_target.assert_called_once_with(
             mock_get_target_name.return_value)
 
@@ -262,18 +269,18 @@ class TestWindowsDriver(test.TestCase):
     def test_copy_image_to_volume(self, mock_unlink, mock_fetch_to_vhd,
                                   mock_tmp_file, mock_local_path):
         tgt_utils = self._driver._tgt_utils
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
 
         mock_tmp_file.return_value.__enter__.return_value = (
             mock.sentinel.tmp_vhd_path)
         mock_local_path.return_value = mock.sentinel.vol_vhd_path
 
         self._driver.copy_image_to_volume(mock.sentinel.context,
-                                          fake_volume,
+                                          volume,
                                           mock.sentinel.image_service,
                                           mock.sentinel.image_id)
 
-        mock_local_path.assert_called_once_with(fake_volume)
+        mock_local_path.assert_called_once_with(volume)
         mock_tmp_file.assert_called_once_with(suffix='.vhd')
         image_utils.fetch_to_vhd.assert_called_once_with(
             mock.sentinel.context, mock.sentinel.image_service,
@@ -287,12 +294,12 @@ class TestWindowsDriver(test.TestCase):
             tgt_utils.get_supported_vhd_type.return_value)
         self._driver._vhdutils.resize_vhd.assert_called_once_with(
             mock.sentinel.vol_vhd_path,
-            fake_volume['size'] * units.Gi,
+            volume.size * units.Gi,
             is_file_max_size=False)
 
         tgt_utils.change_wt_disk_status.assert_has_calls(
-            [mock.call(fake_volume['name'], enabled=False),
-             mock.call(fake_volume['name'], enabled=True)])
+            [mock.call(volume.name, enabled=False),
+             mock.call(volume.name, enabled=True)])
 
     @mock.patch.object(windows.uuidutils, 'generate_uuid')
     def test_temporary_snapshot(self, mock_generate_uuid):
@@ -320,7 +327,7 @@ class TestWindowsDriver(test.TestCase):
 
         disk_format = 'vhd'
         fake_image_meta = db_fakes.get_fake_image_meta()
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
         fake_img_conv_dir = 'fake_img_conv_dir'
         self.flags(image_conversion_dir=fake_img_conv_dir)
 
@@ -333,11 +340,11 @@ class TestWindowsDriver(test.TestCase):
             fake_image_meta['id'] + '.' + disk_format)
 
         self._driver.copy_volume_to_image(
-            mock.sentinel.context, fake_volume,
+            mock.sentinel.context, volume,
             mock.sentinel.image_service,
             fake_image_meta)
 
-        mock_tmp_snap.assert_called_once_with(fake_volume['name'])
+        mock_tmp_snap.assert_called_once_with(volume.name)
         tgt_utils.export_snapshot.assert_called_once_with(
             mock.sentinel.tmp_snap_name,
             expected_tmp_vhd_path)
@@ -353,24 +360,24 @@ class TestWindowsDriver(test.TestCase):
                                   mock_tmp_snap):
         tgt_utils = self._driver._tgt_utils
 
-        fake_volume = db_fakes.get_fake_volume_info()
-        fake_src_volume = db_fakes.get_fake_volume_info_cloned()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
+        src_volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
 
         mock_tmp_snap.return_value.__enter__.return_value = (
             mock.sentinel.tmp_snap_name)
         mock_local_path.return_value = mock.sentinel.vol_vhd_path
 
-        self._driver.create_cloned_volume(fake_volume, fake_src_volume)
+        self._driver.create_cloned_volume(volume, src_volume)
 
-        mock_tmp_snap.assert_called_once_with(fake_src_volume['name'])
+        mock_tmp_snap.assert_called_once_with(src_volume.name)
         tgt_utils.export_snapshot.assert_called_once_with(
             mock.sentinel.tmp_snap_name,
             mock.sentinel.vol_vhd_path)
         self._driver._vhdutils.resize_vhd.assert_called_once_with(
-            mock.sentinel.vol_vhd_path, fake_volume['size'] * units.Gi,
+            mock.sentinel.vol_vhd_path, volume.size * units.Gi,
             is_file_max_size=False)
         tgt_utils.import_wt_disk.assert_called_once_with(
-            mock.sentinel.vol_vhd_path, fake_volume['name'])
+            mock.sentinel.vol_vhd_path, volume.name)
 
     @mock.patch('os.path.splitdrive')
     def test_get_capacity_info(self, mock_splitdrive):
@@ -416,11 +423,11 @@ class TestWindowsDriver(test.TestCase):
                          self._driver._stats)
 
     def test_extend_volume(self):
-        fake_volume = db_fakes.get_fake_volume_info()
+        volume = fake_volume.fake_volume_obj(mock.sentinel.fake_context)
         new_size_gb = 2
         expected_additional_sz_mb = 1024
 
-        self._driver.extend_volume(fake_volume, new_size_gb)
+        self._driver.extend_volume(volume, new_size_gb)
 
         self._driver._tgt_utils.extend_wt_disk.assert_called_once_with(
-            fake_volume['name'], expected_additional_sz_mb)
+            volume.name, expected_additional_sz_mb)

--- a/cinder/volume/drivers/windows/smbfs.py
+++ b/cinder/volume/drivers/windows/smbfs.py
@@ -81,7 +81,7 @@ class WindowsSmbfsDriver(smbfs.SmbfsDriver):
     def _do_create_volume(self, volume):
         volume_path = self.local_path(volume)
         volume_format = self.get_volume_format(volume)
-        volume_size_bytes = volume['size'] * units.Gi
+        volume_size_bytes = volume.size * units.Gi
 
         if os.path.exists(volume_path):
             err_msg = _('File already exists at: %s') % volume_path
@@ -153,7 +153,7 @@ class WindowsSmbfsDriver(smbfs.SmbfsDriver):
 
     def _do_create_snapshot(self, snapshot, backing_file, new_snap_path):
         backing_file_full_path = os.path.join(
-            self._local_volume_dir(snapshot['volume']),
+            self._local_volume_dir(snapshot.volume),
             backing_file)
         self._vhdutils.create_differencing_vhd(new_snap_path,
                                                backing_file_full_path)
@@ -179,7 +179,7 @@ class WindowsSmbfsDriver(smbfs.SmbfsDriver):
         try:
             if backing_file or root_file_fmt == self._DISK_FORMAT_VHDX:
                 temp_file_name = '%s.temp_image.%s.%s' % (
-                    volume['id'],
+                    volume.id,
                     image_meta['id'],
                     self._DISK_FORMAT_VHD)
                 temp_path = os.path.join(self._local_volume_dir(volume),
@@ -211,7 +211,7 @@ class WindowsSmbfsDriver(smbfs.SmbfsDriver):
             self.configuration.volume_dd_blocksize)
 
         self._vhdutils.resize_vhd(self.local_path(volume),
-                                  volume['size'] * units.Gi,
+                                  volume.size * units.Gi,
                                   is_file_max_size=False)
 
     def _copy_volume_from_snapshot(self, snapshot, volume, volume_size):
@@ -219,15 +219,15 @@ class WindowsSmbfsDriver(smbfs.SmbfsDriver):
 
         LOG.debug("snapshot: %(snap)s, volume: %(vol)s, "
                   "volume_size: %(size)s",
-                  {'snap': snapshot['id'],
-                   'vol': volume['id'],
-                   'size': snapshot['volume_size']})
+                  {'snap': snapshot.id,
+                   'vol': volume.id,
+                   'size': snapshot.volume_size})
 
-        info_path = self._local_path_volume_info(snapshot['volume'])
+        info_path = self._local_path_volume_info(snapshot.volume)
         snap_info = self._read_info_file(info_path)
-        vol_dir = self._local_volume_dir(snapshot['volume'])
+        vol_dir = self._local_volume_dir(snapshot.volume)
 
-        forward_file = snap_info[snapshot['id']]
+        forward_file = snap_info[snapshot.id]
         forward_path = os.path.join(vol_dir, forward_file)
 
         # Find the file which backs this file, which represents the point


### PR DESCRIPTION
Cinder has transitioned to using versioned objects,
the Windows SMB driver should reflect this as well.

Change-Id: I0a68177f350eeb8ab0b0a35cc42235a04c7979db